### PR TITLE
fix mailto: link on contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ### 'Ello.
 
 - I’m not mainly working on personal projects right now.
-- You can contact me by [Mail](mailto://ruby3141@gmail.com) \
+- You can contact me by [Mail](mailto:ruby3141@gmail.com) \
   But if you want to ask about personal project I made before, please use Issue tab first.
 
 [![Anurag's github stats](https://github-readme-stats.vercel.app/api?username=ruby3141&show_icons=true&theme=dark)](https://github.com/anuraghazra/github-readme-stats)


### PR DESCRIPTION
I thought it was `mailto://` because it looks more like protocol or something.
Turns out I was an idiot. it is `mailto:`.